### PR TITLE
Corrige 'Loguin' a 'Login' en navigation

### DIFF
--- a/src/views/partials/navigation.hbs
+++ b/src/views/partials/navigation.hbs
@@ -88,7 +88,7 @@
                     </li>
                 {{else}}
                     <li class="nav-item active">
-                        <a class="nav-link" href="/users/signin">Loguin</a>
+                        <a class="nav-link" href="/users/signin">Login</a>
                     </li>
                 {{/if}}
             </ul>      


### PR DESCRIPTION
Se corrigió un error de ortografía "Loguin" a "Login" en Navigation